### PR TITLE
Add dataset cleaning function using pymatgen structurematcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ If you'd like to use the latest unreleased version on the main branch, you can i
 pip install git+https://github.com/jcwang587/cgcnn2
 ```
 
-You can also install from the `dev` branch:
-
-```bash
-pip install git+https://github.com/jcwang587/cgcnn2.git@dev
-```
-
 ## Get Started
 
 ```bash

--- a/cgcnn2/cgcnn_data.py
+++ b/cgcnn2/cgcnn_data.py
@@ -396,6 +396,25 @@ class CIFData_pred(Dataset):
 
 
 def train_force_split(total_set, train_ratio_force_set, train_ratio):
+    """
+    Set up a training dataset with a forced training set.
+
+    Parameters
+    ----------
+    total_set: str
+        The path to the total set
+    train_ratio_force_set: str
+        The path to the forced training set
+    train_ratio: float
+        The ratio of the training set
+
+    Returns
+    -------
+    train_dataset: CIFData
+        The training dataset
+    valid_test_dataset: CIFData
+        The validation set
+    """
     # create a new temporary directory for the training set
     temp_train_dir = tempfile.mkdtemp()
     temp_valid_test_dir = tempfile.mkdtemp()

--- a/cgcnn2/cgcnn_data.py
+++ b/cgcnn2/cgcnn_data.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import torch
 from pymatgen.core.structure import Structure
+from pymatgen.analysis.structure_matcher import StructureMatcher
 from torch.utils.data import Dataset
 
 
@@ -481,3 +482,37 @@ def train_force_split(total_set, train_ratio_force_set, train_ratio):
         raise ValueError(
             f"Forced training set is larger than expected training set. Expected: {train_size}, Forced: {train_force_size}"
         )
+
+
+def check_unique_structures(dataset_dir):
+    """
+    Checks for duplicate (structurally equivalent) structures in a directory 
+    of CIF files using pymatgen's StructureMatcher and returns the count 
+    of unique structures.
+
+    Parameters
+    ----------
+    dataset_dir: str
+        The path to the dataset containing CIF files.
+
+    Returns
+    -------
+    int
+        Number of unique structures.
+    """
+    # Get all CIF files
+    cif_files = [f for f in os.listdir(dataset_dir) if f.endswith(".cif")]
+
+    # Read each file into a pymatgen Structure
+    structures = []
+    for filename in cif_files:
+        full_path = os.path.join(dataset_dir, filename)
+        structure = Structure.from_file(full_path)
+        structures.append(structure)
+    
+    # Group equivalent structures
+    matcher = StructureMatcher()
+    grouped = matcher.group_structures(structures)
+
+    # The number of unique groups = number of unique structures
+    return len(grouped)

--- a/cgcnn2/cgcnn_data.py
+++ b/cgcnn2/cgcnn_data.py
@@ -484,35 +484,40 @@ def train_force_split(total_set, train_ratio_force_set, train_ratio):
         )
 
 
-def check_unique_structures(dataset_dir):
+def unique_structures_clean(dataset_dir, delete_duplicates=False):
     """
-    Checks for duplicate (structurally equivalent) structures in a directory 
-    of CIF files using pymatgen's StructureMatcher and returns the count 
+    Checks for duplicate (structurally equivalent) structures in a directory
+    of CIF files using pymatgen's StructureMatcher and returns the count
     of unique structures.
 
     Parameters
     ----------
     dataset_dir: str
         The path to the dataset containing CIF files.
+    delete_duplicates: bool
+        Whether to delete the duplicate structures, default is False.
 
     Returns
     -------
-    int
-        Number of unique structures.
+    grouped: list
+        A list of lists, where each sublist contains structurally equivalent
+        structures.
     """
-    # Get all CIF files
     cif_files = [f for f in os.listdir(dataset_dir) if f.endswith(".cif")]
 
-    # Read each file into a pymatgen Structure
     structures = []
     for filename in cif_files:
         full_path = os.path.join(dataset_dir, filename)
         structure = Structure.from_file(full_path)
         structures.append(structure)
-    
-    # Group equivalent structures
+
     matcher = StructureMatcher()
     grouped = matcher.group_structures(structures)
 
-    # The number of unique groups = number of unique structures
-    return len(grouped)
+    if delete_duplicates:
+        for group in grouped:
+            if len(group) > 1:
+                for structure in group[1:]:
+                    os.remove(os.path.join(dataset_dir, structure.filename))
+
+    return grouped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgcnn2"
-version = "0.3.4"
+version = "0.3.5"
 description = "Crystal Graph Convolutional Neural Networks"
 authors = ["Jiacheng Wang <jiachengwang@umass.edu>"]
 maintainers = ["Jiacheng Wang"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ ase = "^3.24.0"
 numpy = "*"
 pandas = "*"
 scikit-learn = "*"
-torch = "^2.6.0"
-pymatgen = "^2025.3.0"
+torch = "^2.0.0"
+pymatgen = "^2025.1.9"
 pymatviz = "^0.15.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a functionality to detect and optionally remove duplicate CIF structures, improving dataset integrity.

- **Documentation**
  - Enhanced guidance for the training dataset splitting process.

- **Chores**
  - Upgraded the project version to 0.3.5.
  - Updated dependency versions for `torch` and `pymatgen`.
  - Simplified installation instructions by removing references to the `dev` branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->