### PR TITLE
Sort imports and remove unused imports

### DIFF
--- a/cgcnn2/cgcnn_data.py
+++ b/cgcnn2/cgcnn_data.py
@@ -3,15 +3,15 @@ import functools
 import json
 import os
 import random
-import warnings
 import shutil
 import tempfile
+import warnings
 
 import numpy as np
 import pandas as pd
 import torch
-from pymatgen.core.structure import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher
+from pymatgen.core.structure import Structure
 from torch.utils.data import Dataset
 
 

--- a/cgcnn2/cgcnn_model.py
+++ b/cgcnn2/cgcnn_model.py
@@ -13,9 +13,10 @@ Usage:
     Use the Normalizer class to normalize your target properties during training.
 """
 
+from typing import Dict
+
 import torch
 import torch.nn as nn
-from typing import Dict
 
 
 class ConvLayer(nn.Module):

--- a/cgcnn2/cgcnn_utils.py
+++ b/cgcnn2/cgcnn_utils.py
@@ -1,17 +1,16 @@
-import os
+import argparse
 import csv
 import glob
-import torch
-import argparse
-
-import pandas as pd
-import matplotlib.pyplot as plt
-
+import os
 from datetime import datetime
-from sklearn.metrics import mean_squared_error, r2_score
-from pymatviz import density_hexbin
 
+import matplotlib.pyplot as plt
+import pandas as pd
+import torch
+from pymatviz import density_hexbin
+from sklearn.metrics import mean_squared_error, r2_score
 from torch.utils.data import DataLoader
+
 from .cgcnn_data import CIFData_pred, collate_pool
 from .cgcnn_model import CrystalGraphConvNet, Normalizer
 

--- a/cgcnn2/cli/cgcnn_pr.py
+++ b/cgcnn2/cli/cgcnn_pr.py
@@ -1,27 +1,21 @@
 # Python Standard Library
-import os
-import sys
-import random
 import argparse
+import os
+import random
+import sys
 import warnings
 
 # Third-party Libraries
 import numpy as np
 import torch
-import torch.nn as nn
 from torch.utils.data import DataLoader
-from sklearn.model_selection import train_test_split
-
 
 # Local Application / Specific Library Imports
 from cgcnn2 import (
-    CrystalGraphConvNet,
-    Normalizer,
-    collate_pool,
     CIFData,
-    get_lr,
+    CrystalGraphConvNet,
     cgcnn_test,
-    train_force_split,
+    collate_pool,
 )
 
 

--- a/cgcnn2/cli/cgcnn_tr.py
+++ b/cgcnn2/cli/cgcnn_tr.py
@@ -1,7 +1,6 @@
 # Python Standard Library
 import os
 import random
-import argparse
 import warnings
 from random import sample
 
@@ -9,22 +8,20 @@ from random import sample
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
 from sklearn.model_selection import train_test_split
-
+from torch.utils.data import DataLoader
 
 # Local Application / Specific Library Imports
 from cgcnn2 import (
+    CIFData,
     CrystalGraphConvNet,
     Normalizer,
+    cgcnn_test,
     collate_pool,
-    CIFData,
     get_lr,
     parse_arguments,
-    cgcnn_test,
     train_force_split,
 )
-
 
 # Suppress specific warnings from pymatgen
 warnings.filterwarnings("ignore", category=UserWarning, module="pymatgen.io.cif")


### PR DESCRIPTION
This PR sorts the imports using `ruff` (essentially the same as running `isort`) and removes unused imports. Feel free to reject this PR since it is mostly stylistic and you have only specified `black` as the formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reorganized internal structure to boost code clarity and maintainability.
- **Chores**
	- Removed unused dependencies to streamline the codebase.

These internal improvements ensure a more optimized and easier-to-maintain system, with no visible impact on user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->