### PR TITLE
Fix docstring for `ConvLayer`

### DIFF
--- a/cgcnn2/model.py
+++ b/cgcnn2/model.py
@@ -29,8 +29,8 @@ class ConvLayer(nn.Module):
         Initialize the ConvLayer.
 
         Args:
-            atom_feature_len (int): Number of atom hidden features.
-            neighbor_feature_len (int): Number of bond (neighbor) features.
+            atom_fea_len (int): Number of atom hidden features.
+            nbr_fea_len (int): Number of bond (neighbor) features.
         """
         super(ConvLayer, self).__init__()
         self.atom_fea_len = atom_fea_len


### PR DESCRIPTION
The arguments in the docstring of the `__init__` for `ConvLayer` were incorrect, so I updated them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated internal documentation details to ensure clarity and consistency in parameter naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->