### PR TITLE
Allow custom x‑ and y‑axis labels in parity plot

### DIFF
--- a/cgcnn2/cli/cgcnn_ft.py
+++ b/cgcnn2/cli/cgcnn_ft.py
@@ -196,6 +196,20 @@ def parse_arguments(args=None):
         help="Axis limits for the parity plot",
     )
     parser.add_argument(
+        "-x",
+        "--xlabel",
+        type=str,
+        default="Actual",
+        help="X-axis label for the parity plot",
+    )
+    parser.add_argument(
+        "-y",
+        "--ylabel",
+        type=str,
+        default="Predicted",
+        help="Y-axis label for the parity plot",
+    )
+    parser.add_argument(
         "-ji",
         "--job-id",
         type=str,
@@ -528,8 +542,8 @@ def main():
         args.device,
         plot_file=os.path.join(output_folder, "parity_plot.svg"),
         results_file=os.path.join(output_folder, "test_results.csv"),
-        xlabel="Actual (eV)",
-        ylabel="Predicted (eV)",
+        xlabel=args.xlabel,
+        ylabel=args.ylabel,
         axis_limits=args.axis_limits,
     )
 

--- a/cgcnn2/cli/cgcnn_pr.py
+++ b/cgcnn2/cli/cgcnn_pr.py
@@ -70,6 +70,20 @@ def parse_arguments(args=None):
         help="Axis limits for the parity plot",
     )
     parser.add_argument(
+        "-x",
+        "--xlabel",
+        type=str,
+        default="Actual",
+        help="X-axis label for the parity plot",
+    )
+    parser.add_argument(
+        "-y",
+        "--ylabel",
+        type=str,
+        default="Predicted",
+        help="Y-axis label for the parity plot",
+    )
+    parser.add_argument(
         "-ji",
         "--job-id",
         type=str,
@@ -150,8 +164,8 @@ def main():
         device=args.device,
         plot_file=os.path.join(output_folder, "parity_plot.svg"),
         results_file=os.path.join(output_folder, "results.csv"),
-        xlabel="Actual (eV)",
-        ylabel="Predicted (eV)",
+        xlabel=args.xlabel,
+        ylabel=args.ylabel,
         axis_limits=args.axis_limits,
     )
 

--- a/cgcnn2/cli/cgcnn_tr.py
+++ b/cgcnn2/cli/cgcnn_tr.py
@@ -166,6 +166,20 @@ def parse_arguments(args=None):
         help="Axis limits for the parity plot",
     )
     parser.add_argument(
+        "-x",
+        "--xlabel",
+        type=str,
+        default="Actual",
+        help="X-axis label for the parity plot",
+    )
+    parser.add_argument(
+        "-y",
+        "--ylabel",
+        type=str,
+        default="Predicted",
+        help="Y-axis label for the parity plot",
+    )
+    parser.add_argument(
         "-ji",
         "--job-id",
         default=f"{os.getpid()}",
@@ -466,8 +480,8 @@ def main():
         args.device,
         plot_file=os.path.join(output_folder, "parity_plot.svg"),
         results_file=os.path.join(output_folder, "test_results.csv"),
-        xlabel="Actual (eV)",
-        ylabel="Predicted (eV)",
+        xlabel=args.xlabel,
+        ylabel=args.ylabel,
         axis_limits=args.axis_limits,
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added command-line options to customize the x-axis and y-axis labels for parity plots in various CLI tools.

- **Bug Fixes**
  - Improved duplicate structure handling by accurately tracking and deleting duplicate CIF files based on filenames.

- **Other**
  - The function for identifying unique structures now returns grouped filenames instead of structure objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->