### PR TITLE
switch svg to png

### DIFF
--- a/cgcnn2/cli/cgcnn_ft.py
+++ b/cgcnn2/cli/cgcnn_ft.py
@@ -553,7 +553,7 @@ def main():
         model,
         test_loader,
         args.device,
-        plot_file=os.path.join(output_folder, "parity_plot.svg"),
+        plot_file=os.path.join(output_folder, "parity_plot.png"),
         results_file=os.path.join(output_folder, "test_results.csv"),
         xlabel=args.xlabel,
         ylabel=args.ylabel,

--- a/cgcnn2/cli/cgcnn_pr.py
+++ b/cgcnn2/cli/cgcnn_pr.py
@@ -161,7 +161,7 @@ def main():
         model=model,
         loader=loader,
         device=args.device,
-        plot_file=os.path.join(output_folder, "parity_plot.svg"),
+        plot_file=os.path.join(output_folder, "parity_plot.png"),
         results_file=os.path.join(output_folder, "results.csv"),
         xlabel=args.xlabel,
         ylabel=args.ylabel,

--- a/cgcnn2/cli/cgcnn_tr.py
+++ b/cgcnn2/cli/cgcnn_tr.py
@@ -483,7 +483,7 @@ def main():
         model,
         test_loader,
         args.device,
-        plot_file=os.path.join(output_folder, "parity_plot.svg"),
+        plot_file=os.path.join(output_folder, "parity_plot.png"),
         results_file=os.path.join(output_folder, "test_results.csv"),
         xlabel=args.xlabel,
         ylabel=args.ylabel,

--- a/cgcnn2/util.py
+++ b/cgcnn2/util.py
@@ -162,7 +162,7 @@ def cgcnn_test(
         model (torch.nn.Module): The pre-trained CGCNN model.
         loader (torch.utils.data.DataLoader): DataLoader for the dataset.
         device (str): The device ('cuda' or 'cpu') where the model will be run.
-        plot_file (str, optional): File path for saving the parity plot. Defaults to 'parity_plot.svg'.
+        plot_file (str, optional): File path for saving the parity plot. Defaults to 'parity_plot.png'.
         results_file (str, optional): File path for saving results as CSV. Defaults to 'results.csv'.
         axis_limits (list, optional): Limits for x and y axes of the parity plot. Defaults to None.
         **kwargs: Additional keyword arguments:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the output format of parity plots from SVG to PNG across relevant commands.
- **Documentation**
	- Updated documentation to reflect the new default file extension for parity plot outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->