### PR TITLE
Replace manual cache with pip cache

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -36,15 +36,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Set cache ID
-        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
+          cache: 'pip'
+          cache-dependency-path: docs/requirements.txt
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined documentation build pipeline by replacing manual cache steps with built-in pip caching via actions/setup-python@v5.
  * Enabled automatic dependency caching using docs/requirements.txt to speed up and stabilize docs builds.
  * Reduced workflow complexity and maintenance overhead by removing custom cache keys and restore logic.
  * No changes to documentation content or deployment behavior; GitHub Pages deployment remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->