### PR TITLE
Update GitHub Actions workflow to use uv version 8.3.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -32,7 +32,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           args: -l 2
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.0
       - name: Build package with uv
         run: uv build
       - name: Publish package to PyPI


### PR DESCRIPTION
- Changed the setup-uv action version from v8 to v8.3.0 for improved stability and features.