### PR TITLE
Pool crystals with scatter_reduce over a flat crystal index

### DIFF
--- a/cgcnn2/cli/cgcnn_ft.py
+++ b/cgcnn2/cli/cgcnn_ft.py
@@ -457,7 +457,7 @@ def main():
             atom_fea = atom_fea.to(args.device)
             nbr_fea = nbr_fea.to(args.device)
             nbr_fea_idx = nbr_fea_idx.to(args.device)
-            crystal_atom_idx = [idx_map.to(args.device) for idx_map in crystal_atom_idx]
+            crystal_atom_idx = crystal_atom_idx.to(args.device)
             targets = targets.to(args.device)
 
             # Forward pass
@@ -488,9 +488,7 @@ def main():
                 atom_fea = atom_fea.to(args.device)
                 nbr_fea = nbr_fea.to(args.device)
                 nbr_fea_idx = nbr_fea_idx.to(args.device)
-                crystal_atom_idx = [
-                    idx_map.to(args.device) for idx_map in crystal_atom_idx
-                ]
+                crystal_atom_idx = crystal_atom_idx.to(args.device)
                 targets = targets.to(args.device)
 
                 outputs, _ = model(atom_fea, nbr_fea, nbr_fea_idx, crystal_atom_idx)

--- a/cgcnn2/cli/cgcnn_tr.py
+++ b/cgcnn2/cli/cgcnn_tr.py
@@ -374,7 +374,7 @@ def main():
             atom_fea = atom_fea.to(args.device)
             nbr_fea = nbr_fea.to(args.device)
             nbr_fea_idx = nbr_fea_idx.to(args.device)
-            crystal_atom_idx = [idx_map.to(args.device) for idx_map in crystal_atom_idx]
+            crystal_atom_idx = crystal_atom_idx.to(args.device)
             targets = targets.to(args.device)
 
             optimizer.zero_grad()
@@ -407,9 +407,7 @@ def main():
                 atom_fea = atom_fea.to(args.device)
                 nbr_fea = nbr_fea.to(args.device)
                 nbr_fea_idx = nbr_fea_idx.to(args.device)
-                crystal_atom_idx = [
-                    idx_map.to(args.device) for idx_map in crystal_atom_idx
-                ]
+                crystal_atom_idx = crystal_atom_idx.to(args.device)
                 targets = targets.to(args.device)
 
                 outputs, _ = model(atom_fea, nbr_fea, nbr_fea_idx, crystal_atom_idx)

--- a/cgcnn2/data.py
+++ b/cgcnn2/data.py
@@ -34,7 +34,7 @@ def collate_pool(dataset_list):
         batch_atom_fea (torch.Tensor): shape (N, orig_atom_fea_len) Atom features from atom type
         batch_nbr_fea (torch.Tensor): shape (N, M, nbr_fea_len) Bond features of each atom's M neighbors
         batch_nbr_fea_idx (torch.LongTensor): shape (N, M) Indices of M neighbors of each atom
-        crystal_atom_idx (list of torch.LongTensor): length N0 Mapping from the crystal idx to atom idx
+        crystal_atom_idx (torch.LongTensor): shape (N,) Index of the crystal each atom belongs to, sorted ascending
         batch_target (torch.Tensor): shape (N, 1) Target value for prediction
         batch_cif_ids (list of str or int): Unique IDs for each crystal
     """
@@ -43,13 +43,14 @@ def collate_pool(dataset_list):
     crystal_atom_idx, batch_target = [], []
     batch_cif_ids = []
     base_idx = 0
-    for (atom_fea, nbr_fea, nbr_fea_idx), target, cif_id in dataset_list:
+    for crystal_i, ((atom_fea, nbr_fea, nbr_fea_idx), target, cif_id) in enumerate(
+        dataset_list
+    ):
         n_i = atom_fea.shape[0]  # number of atoms for this crystal
         batch_atom_fea.append(atom_fea)
         batch_nbr_fea.append(nbr_fea)
         batch_nbr_fea_idx.append(nbr_fea_idx + base_idx)
-        new_idx = torch.arange(base_idx, base_idx + n_i, dtype=torch.long)
-        crystal_atom_idx.append(new_idx)
+        crystal_atom_idx.append(torch.full((n_i,), crystal_i, dtype=torch.long))
         batch_target.append(target)
         batch_cif_ids.append(cif_id)
         base_idx += n_i
@@ -58,7 +59,7 @@ def collate_pool(dataset_list):
             torch.cat(batch_atom_fea, dim=0),
             torch.cat(batch_nbr_fea, dim=0),
             torch.cat(batch_nbr_fea_idx, dim=0),
-            crystal_atom_idx,
+            torch.cat(crystal_atom_idx, dim=0),
         ),
         torch.stack(batch_target, dim=0),
         batch_cif_ids,

--- a/cgcnn2/model.py
+++ b/cgcnn2/model.py
@@ -130,7 +130,7 @@ class CrystalGraphConvNet(nn.Module):
         atom_fea: torch.Tensor,
         nbr_fea: torch.Tensor,
         nbr_fea_idx: torch.LongTensor,
-        crystal_atom_idx: list[torch.LongTensor],
+        crystal_atom_idx: torch.LongTensor,
     ):
         """
         Forward pass.
@@ -143,7 +143,7 @@ class CrystalGraphConvNet(nn.Module):
             atom_fea (torch.Tensor): Tensor of shape `(N, orig_atom_fea_len)` containing the atom features from atom type.
             nbr_fea (torch.Tensor): Tensor of shape `(N, M, nbr_fea_len)` containing the bond features of each atom's `M` neighbors.
             nbr_fea_idx (torch.LongTensor): Tensor of shape `(N, M)` containing the indices of the `M` neighbors of each atom.
-            crystal_atom_idx (list of torch.LongTensor): Mapping from the crystal index to atom index.
+            crystal_atom_idx (torch.LongTensor): Tensor of shape `(N,)` mapping each atom to the index of its crystal, sorted ascending.
 
         Returns:
             out (torch.Tensor):
@@ -169,20 +169,21 @@ class CrystalGraphConvNet(nn.Module):
         return out, crys_fea
 
     def pooling(
-        self, atom_fea: torch.Tensor, crystal_atom_idx: list[torch.LongTensor]
+        self, atom_fea: torch.Tensor, crystal_atom_idx: torch.LongTensor
     ) -> torch.Tensor:
         """
         Aggregate atom features into crystal-level features by mean pooling.
 
         Args:
             atom_fea (torch.Tensor): Tensor of shape `(N, atom_fea_len)` containing the atom embeddings for all atoms in the batch.
-            crystal_atom_idx (list[torch.LongTensor]): List of tensors, where `crystal_atom_idx[i]` contains the indices of atoms belonging to the `i`-th crystal. The concatenated indices must cover every atom exactly once.
+            crystal_atom_idx (torch.LongTensor): Tensor of shape `(N,)` mapping each atom to the index of its crystal, sorted ascending. Every atom must belong to exactly one crystal.
 
         Returns:
             mean_fea (torch.Tensor): Tensor of shape `(n_crystals, atom_fea_len)` containing the mean-pooled crystal embeddings.
         """
-        assert sum(len(idx) for idx in crystal_atom_idx) == atom_fea.shape[0]
-        mean_fea = torch.stack(
-            [torch.mean(atom_fea[idx], dim=0) for idx in crystal_atom_idx], dim=0
+        n_crystals = int(crystal_atom_idx[-1]) + 1
+        index = crystal_atom_idx.unsqueeze(1).expand(-1, atom_fea.shape[1])
+        mean_fea = atom_fea.new_zeros(n_crystals, atom_fea.shape[1]).scatter_reduce_(
+            0, index, atom_fea, reduce="mean", include_self=False
         )
         return mean_fea

--- a/cgcnn2/utils.py
+++ b/cgcnn2/utils.py
@@ -561,7 +561,7 @@ def cgcnn_test(
             atom_fea = atom_fea.to(device)
             nbr_fea = nbr_fea.to(device)
             nbr_fea_idx = nbr_fea_idx.to(device)
-            crystal_atom_idx = [idx_map.to(device) for idx_map in crystal_atom_idx]
+            crystal_atom_idx = crystal_atom_idx.to(device)
             target = target.to(device)
             output, _ = model(atom_fea, nbr_fea, nbr_fea_idx, crystal_atom_idx)
 
@@ -648,7 +648,7 @@ def cgcnn_descriptor(
             atom_fea = atom_fea.to(device)
             nbr_fea = nbr_fea.to(device)
             nbr_fea_idx = nbr_fea_idx.to(device)
-            crystal_atom_idx = [idx_map.to(device) for idx_map in crystal_atom_idx]
+            crystal_atom_idx = crystal_atom_idx.to(device)
             target = target.to(device)
 
             output, crys_fea = model(atom_fea, nbr_fea, nbr_fea_idx, crystal_atom_idx)


### PR DESCRIPTION
## Summary
- `collate_pool` now emits `crystal_atom_idx` as a single `(N,)` LongTensor mapping each atom to its crystal, replacing the list of per-crystal index tensors.
- `CrystalGraphConvNet.pooling` aggregates with one `scatter_reduce_(reduce="mean")` call instead of a Python loop over crystals (previously one kernel launch per crystal - 256 per batch at the default batch size). This also removes the main obstacle to `torch.compile`.
- Call sites (`cgcnn_test`, `cgcnn_descriptor`, both training loops) move the index to the device with a single copy instead of one transfer per crystal.

## Breaking change
The model `forward` interface changes for code that builds batches manually; anything using `collate_pool` with a `DataLoader` (the documented pattern) is unaffected.

## Verification
- Pooled features match the previous loop implementation to 1e-6; end-to-end `cgcnn-tr` smoke run passes.

Part 2/4, stacked on #163 (`perf/data-fast-graph`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)